### PR TITLE
Update index.html

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -564,7 +564,7 @@
 
 	L.TileLayer.Provider.providers = {
 		OpenStreetMap: {
-			url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				maxZoom: 19,
 				attribution:


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.